### PR TITLE
Set Basic Constraints extension critical in CA certificates

### DIFF
--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -159,7 +159,7 @@ int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
 
     return mbedtls_x509write_crt_set_extension( ctx, MBEDTLS_OID_BASIC_CONSTRAINTS,
                                         MBEDTLS_OID_SIZE( MBEDTLS_OID_BASIC_CONSTRAINTS ),
-                                        0, buf + sizeof(buf) - len, len );
+                                        is_ca, buf + sizeof(buf) - len, len );
 }
 
 #if defined(MBEDTLS_SHA1_C)


### PR DESCRIPTION
According to RFC5280 section 4.2.1.9, the Basic Constraints extension MUST be marked critical in all CA certificates that contain public keys used to validate digital signatures on certificates.

## Description
This is a necessary change to make CA certificates created by mbedTLS to work for instance when used as intermediaries in a TLS trust chain with many browsers.

## Status
READY

## Requires Backporting
Hopefully

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Create a new certificate by the mbedtls_x509_write_crt_* family of functions. Set Basic Constraints extension to 1. Check the the extension is marked critical in the result certificate.